### PR TITLE
All antipattern titles are now sentence-cased. Consistently hyphenating 'inappropriately-specific name'.

### DIFF
--- a/content/antipatterns/inappropriately_specific_name.mdx
+++ b/content/antipatterns/inappropriately_specific_name.mdx
@@ -1,5 +1,5 @@
 ---
-title: Inappropriately specific name
+title: Inappropriately-specific name
 ---
 # Inappropriately-specific name
 

--- a/content/antipatterns/name_type_mismatch.mdx
+++ b/content/antipatterns/name_type_mismatch.mdx
@@ -1,8 +1,8 @@
 ---
-title: Name/Type Mismatch
+title: Name/type mismatch
 ---
 
-# Name/Type Mismatch
+# Name/type Mismatch
 
 ## Description
 

--- a/content/antipatterns/unexpected_effects.mdx
+++ b/content/antipatterns/unexpected_effects.mdx
@@ -1,7 +1,7 @@
 ---
-title: Unexpected Side Effects
+title: Unexpected side effects
 ---
-# Unexpected Side Effects
+# Unexpected side effects
 
 ## Description
 


### PR DESCRIPTION
Addresses #1. 