### PR TITLE
A friendly typo fix

### DIFF
--- a/content/antipatterns/missing_implied_return_type.mdx
+++ b/content/antipatterns/missing_implied_return_type.mdx
@@ -1,5 +1,5 @@
 ---
-title: Missing impled return type
+title: Missing implied return type
 ---
 # Missing implied return type
 


### PR DESCRIPTION
Fixes a typo in `missing_implied_return_type.mdx` where it used to say `impled` instead of `implied`.