### PR TITLE
Capitalize “Name/type mismatch” heading consistently

### DIFF
--- a/content/antipatterns/name_type_mismatch.mdx
+++ b/content/antipatterns/name_type_mismatch.mdx
@@ -2,7 +2,7 @@
 title: Name/type mismatch
 ---
 
-# Name/type Mismatch
+# Name/type mismatch
 
 ## Description
 


### PR DESCRIPTION
A follow-up fix for https://github.com/Linguistic-Antipatterns/linguistic-antipatterns.github.io/issues/1